### PR TITLE
Fix non pagination query in fnbs

### DIFF
--- a/src/fnbs/fnbs.controller.ts
+++ b/src/fnbs/fnbs.controller.ts
@@ -9,6 +9,7 @@ import {
   Query,
   DefaultValuePipe,
   ParseIntPipe,
+  ParseBoolPipe,
 } from '@nestjs/common';
 import { FnbsService } from './fnbs.service';
 import { Prisma } from '@prisma/client';
@@ -23,8 +24,12 @@ export class FnbsController {
   }
 
   @Get()
-  findAll(@Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number) {
-    return this.fnbsService.findAll(page);
+  findAll(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('pagination', new DefaultValuePipe(true), ParseBoolPipe)
+    pagination?: boolean,
+  ) {
+    return this.fnbsService.findAll(page, pagination);
   }
 
   @Get(':id')

--- a/src/fnbs/fnbs.service.ts
+++ b/src/fnbs/fnbs.service.ts
@@ -29,11 +29,21 @@ export class FnbsService {
     }
   }
 
-  async findAll(page?: number): Promise<Response<Fnbs[]>> {
-    const take = 15;
+  async findAll(
+    page?: number,
+    pagination?: boolean,
+  ): Promise<Response<Fnbs[]>> {
+    let take: number | undefined;
+    let skip: number | undefined;
 
     try {
-      const skip = countSkip(take, page);
+      if (pagination === false) {
+        take = undefined;
+        skip = undefined;
+      } else {
+        take = 15;
+        skip = countSkip(take, page);
+      }
 
       // eslint-disable-next-line prefer-const
       const [fnbs, totalFnbs] = await Promise.all([


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced list retrieval endpoints with an optional pagination parameter. By default, responses are paginated, but users can disable pagination to retrieve all available data in a single request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->